### PR TITLE
Install gcsfs in image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN micromamba install -y -n base -f /tmp/env.yml && \
 
 RUN micromamba run pip install --no-cache "quetz-server" "pydantic<2" "xattr"
 
-RUN micromamba run pip install quetz-frontend
+RUN micromamba run pip install quetz-frontend gcsfs
 
 COPY wait-for-it.sh /usr/bin/wait-for-it.sh
 


### PR DESCRIPTION
Since we use a Google cloud storage backend installing gcsfs in the image can reduce container startup time. If the image is intended to be public, generic, and storage backend agnostic, would it be better if we build a separate image intended for GCP with a GCP tag to it?

The image seems to be around 830 MB at the moment. I looked into the files in the image, and it doesn't look like we can reduce it much further as I'm assuming all of the larger packages shown below are essential for Quetz and it's frontend.

![image](https://github.com/wolfv/quetz-docker/assets/114400911/eb80b491-6f91-4e5a-94f0-84aa26152ba3)
